### PR TITLE
Add enum support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl ToString for Casing {
 
 impl Casing {
     const fn all() -> &'static [&'static str] {
-        return &[
+        &[
             "PascalCase",
             "CamelCase",
             "LowerCase",
@@ -75,7 +75,7 @@ impl Casing {
             "ScreamingSnakeCase",
             "KebabCase",
             "ScreamingKebabCase",
-        ];
+        ]
     }
 }
 
@@ -101,14 +101,12 @@ pub fn serde_alias(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut aliases = vec![];
 
     for arg in args {
-        if let NestedMeta::Meta(meta) = arg {
-            if let Meta::Path(path) = meta {
-                let case_ident = path.get_ident().expect("expected casing");
-                let case =
-                    Casing::from_str(&case_ident.to_string()).unwrap_or_else(|e| panic!("{}", e));
+        if let NestedMeta::Meta(Meta::Path(path)) = arg {
+            let case_ident = path.get_ident().expect("expected casing");
+            let case =
+                Casing::from_str(&case_ident.to_string()).unwrap_or_else(|e| panic!("{}", e));
 
-                aliases.push(case);
-            }
+            aliases.push(case);
         }
     }
 
@@ -165,7 +163,7 @@ fn alias_enum(aliases: Vec<Casing>, mut input: ItemEnum) -> TokenStream {
     }
 
     let tokens = quote! {#input};
-    return tokens.into();
+    tokens.into()
 }
 
 fn create_field_attribute(casings: Vec<String>) -> Attribute {

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -1,0 +1,79 @@
+use serde::{Deserialize, Serialize};
+use serde_alias::serde_alias;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Foo<V> {
+    var1: V,
+    var2: V,
+    var3: V,
+}
+
+macro_rules! assert_valid_json_casing {
+    ($json:expr, $case:ident) => {
+        #[serde_alias($case)]
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        enum FooVar {
+            Bar,
+            Baz,
+            FooBar,
+        }
+
+        let actual: Foo<FooVar> = serde_json::from_str($json).expect("valid JSON");
+
+        let expected = Foo {
+            var1: FooVar::Bar,
+            var2: FooVar::Baz,
+            var3: FooVar::FooBar,
+        };
+
+        assert_eq!(actual, expected);
+    };
+}
+
+#[test]
+fn camel() {
+    let json = r#"{"var1": "bar", "var2": "baz", "var3": "fooBar"}"#;
+    assert_valid_json_casing!(json, CamelCase);
+}
+
+#[test]
+fn pascal() {
+    let json = r#"{"var1": "Bar", "var2": "Baz", "var3": "FooBar"}"#;
+    assert_valid_json_casing!(json, PascalCase);
+}
+
+#[test]
+fn lower() {
+    let json = r#"{"var1": "bar", "var2": "baz", "var3": "foo bar"}"#;
+    assert_valid_json_casing!(json, LowerCase);
+}
+
+#[test]
+fn upper() {
+    let json = r#"{"var1": "BAR", "var2": "BAZ", "var3": "FOO BAR"}"#;
+    assert_valid_json_casing!(json, UpperCase);
+}
+
+#[test]
+fn snake() {
+    let json = r#"{"var1": "bar", "var2": "baz", "var3": "foo_bar"}"#;
+    assert_valid_json_casing!(json, SnakeCase);
+}
+
+#[test]
+fn screaming_snake() {
+    let json = r#"{"var1": "BAR", "var2": "BAZ", "var3": "FOO_BAR"}"#;
+    assert_valid_json_casing!(json, ScreamingSnakeCase);
+}
+
+#[test]
+fn kebab() {
+    let json = r#"{"var1": "bar", "var2": "baz", "var3": "foo-bar"}"#;
+    assert_valid_json_casing!(json, KebabCase);
+}
+
+#[test]
+fn screaming_kebab() {
+    let json = r#"{"var1": "BAR", "var2": "BAZ", "var3": "FOO-BAR"}"#;
+    assert_valid_json_casing!(json, ScreamingKebabCase);
+}


### PR DESCRIPTION
- The macro can now support adding aliases to enums as well as structs. 
- Refactored the common operations into utility functions.
- Added tests for enum aliases.
- Removed clippy warnings.

See #1 